### PR TITLE
Fix bug in CORSFilter (stupid Properties class)

### DIFF
--- a/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/cors/CORSFilter.java
+++ b/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/cors/CORSFilter.java
@@ -125,7 +125,7 @@ public class CORSFilter implements ContainerResponseFilter, ContainerRequestFilt
 		}
 		
 		List<String> originsList = new ArrayList<>();
-		if(this.config.containsKey(CONFIG_ORIGINS_KEY)) {			
+		if(this.config.getProperty(CONFIG_ORIGINS_KEY) != null) {
 			// Load pipe-separated list of allowed origins from config
 			String[] origins = this.config.getProperty(CONFIG_ORIGINS_KEY).split("\\|");
 			// Convert primitive array to list


### PR DESCRIPTION
Turns out that Properties.containsKey doesn’t take default values into
account.

The Core now uses default properties extensively, that’s why this bug
only just came to the surface.

This is a bug fix

Pull request status:
- [ ] Tests added/updated
- [x] Ready for review