### PR TITLE
Small refactoring of Calendar Plugin

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -45,8 +45,8 @@
 	<logger name="default.config.edu.cmu.sphinx" level="WARN" />
 	<logger name="org.glassfish.grizzly.http.server" level="WARN" />
 	<logger name="marytts.TextToMaryXML" level="ERROR" />
-	<logger name="org.glassfish.jersey.internal.inject.Providers"
-		level="ERROR" />
+	<logger name="org.glassfish.jersey.internal.inject.Providers" level="ERROR" />
+	<logger name="com.google.api.client.util.store.FileDataStoreFactory" level="OFF" />
 
 	<root level="WARN">
 		<appender-ref ref="STDOUT" />

--- a/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
+++ b/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
@@ -314,7 +314,12 @@ public class CalendarLogic {
 	 */
 	public String eventToString(LocalDateTime startDate, LocalDateTime endDate, Event event, boolean withStartDate,
 			boolean withEndDate, boolean withTime, OutputCase outputCase) {
-		String eventData = event.getSummary();
+		String eventData = "";
+		if (event.getSummary() == null || event.getSummary() == "") {
+			eventData += "An event without a title";
+		} else {
+			eventData += event.getSummary();
+		}		 
 		String eventStartDate = dateOutput(startDate, withStartDate, withTime);
 		String eventEndDate = dateOutput(endDate, withEndDate, withTime);
 		String eventStartTime = "";

--- a/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
+++ b/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
@@ -314,7 +314,7 @@ public class CalendarLogic {
 	 */
 	public String eventToString(LocalDateTime startDate, LocalDateTime endDate, Event event, boolean withStartDate,
 			boolean withEndDate, boolean withTime, OutputCase outputCase) {
-		String eventData = setTitle(event.getSummary());
+		String eventData = convertEventTitle(event.getSummary());
 		String eventStartDate = dateOutput(startDate, withStartDate, withTime);
 		String eventEndDate = dateOutput(endDate, withEndDate, withTime);
 		String eventStartTime = "";
@@ -361,10 +361,13 @@ public class CalendarLogic {
 		return eventData;
 	}
 	
-	/*
+	/**
 	 * Checks if given event summary is empty/ null and returns an alternative String or the title
+	 * 
+	 * @param title the title String of the event
+	 * @return the title part of the event for Amy output
 	 */
-	private String setTitle(String title) {
+	private String convertEventTitle(String title) {
 		if(title == null || title.equals("")) {
 			return "An event without a title";
 		}

--- a/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
+++ b/plugins/calendar/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogic.java
@@ -314,12 +314,7 @@ public class CalendarLogic {
 	 */
 	public String eventToString(LocalDateTime startDate, LocalDateTime endDate, Event event, boolean withStartDate,
 			boolean withEndDate, boolean withTime, OutputCase outputCase) {
-		String eventData = "";
-		if (event.getSummary() == null || event.getSummary() == "") {
-			eventData += "An event without a title";
-		} else {
-			eventData += event.getSummary();
-		}		 
+		String eventData = setTitle(event.getSummary());
 		String eventStartDate = dateOutput(startDate, withStartDate, withTime);
 		String eventEndDate = dateOutput(endDate, withEndDate, withTime);
 		String eventStartTime = "";
@@ -364,6 +359,16 @@ public class CalendarLogic {
 		}
 
 		return eventData;
+	}
+	
+	/*
+	 * Checks if given event summary is empty/ null and returns an alternative String or the title
+	 */
+	private String setTitle(String title) {
+		if(title == null || title.equals("")) {
+			return "An event without a title";
+		}
+		return title;
 	}
 
 	/**

--- a/plugins/calendar/src/test/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogicTest.java
+++ b/plugins/calendar/src/test/java/de/unistuttgart/iaas/amyassist/amy/plugin/calendar/CalendarLogicTest.java
@@ -150,7 +150,11 @@ public class CalendarLogicTest {
 				Pair.of(event("event start today end tomorrow", "2015-05-28T15:30:00", "2015-05-29T15:30:00"),
 						"event start today end tomorrow from the 28th of may at 15:30 until the 29th of may at 15:30."),
 				Pair.of(eventAllDay("event tomorrow all day", "2015-05-29", "2015-05-30"),
-						"event tomorrow all day on the 29th of may all day long."));
+						"event tomorrow all day on the 29th of may all day long."),
+				Pair.of(eventAllDay("", "2015-05-29", "2015-05-30"),
+						"An event without a title on the 29th of may all day long."),
+				Pair.of(eventAllDay(null, "2015-05-29", "2015-05-30"),
+						"An event without a title on the 29th of may all day long."));
 	}
 
 	/**


### PR DESCRIPTION
Getting rid of the the google warn while connecting to the calendar, which is a google side bug.
Fixing a mistake in the String output of Amy:
When there is an event with no title, Amy has following response: "null from ....", now I'm changing it to "An event without a title from ...". Same for events with an empty String as title.

#179 

Pull request status:
- [x] Tests added/updated
- [x] 80 % Coverage
- [x] Code conventions
- [x] Ready for review
