### PR TITLE
Add DialogHandler.hasDialogUnfinishedIntent(UUID)

### DIFF
--- a/core/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandlerImpl.java
+++ b/core/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandlerImpl.java
@@ -72,9 +72,8 @@ public class DialogHandlerImpl implements DialogHandler {
 
 	@Override
 	public void process(String naturalLanguageText, UUID uuid) {
-		if (!this.map.containsKey(uuid)) {
+		if (!this.map.containsKey(uuid))
 			throw new IllegalArgumentException("wrong UUID");
-		}
 
 		Dialog dialog = this.map.get(uuid);
 		UserIntent intent = dialog.getIntent();
@@ -101,6 +100,19 @@ public class DialogHandlerImpl implements DialogHandler {
 			}
 			dialog.setIntent(null);
 		}
+	}
+
+	/**
+	 * @see de.unistuttgart.iaas.amyassist.amy.core.natlang.DialogHandler#hasDialogUnfinishedIntent(java.util.UUID)
+	 */
+	@Override
+	public boolean hasDialogUnfinishedIntent(UUID uuid) {
+		if (!this.map.containsKey(uuid))
+			throw new IllegalArgumentException("wrong UUID");
+
+		UserIntent intent = this.map.get(uuid).getIntent();
+
+		return (intent != null && intent.isFinished());
 	}
 
 }

--- a/core/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandlerImpl.java
+++ b/core/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandlerImpl.java
@@ -112,7 +112,7 @@ public class DialogHandlerImpl implements DialogHandler {
 
 		UserIntent intent = this.map.get(uuid).getIntent();
 
-		return (intent != null && intent.isFinished());
+		return (intent != null && !intent.isFinished());
 	}
 
 }

--- a/natlang-api/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandler.java
+++ b/natlang-api/src/main/java/de/unistuttgart/iaas/amyassist/amy/core/natlang/DialogHandler.java
@@ -65,4 +65,13 @@ public interface DialogHandler {
 	 */
 	void process(String naturalLanguageText, UUID uuid);
 
+	/**
+	 * Checks whether the dialog with the given id currently has an unfinished intent.
+	 * 
+	 * @param uuid
+	 *            The id of the dialog to check
+	 * 
+	 * @return Whether the it has a unfinished intent.
+	 */
+	boolean hasDialogUnfinishedIntent(UUID uuid);
 }


### PR DESCRIPTION
[Minor Change][Addition] Adds a method the the dialog handler, with which you can check if a dialog has an unfinished intent.
Closes #392.

Pull request status:
- [x] Code conventions
- [x] Ready for review
