### PR TITLE
Increase maximum allowed startup time for Chrome

### DIFF
--- a/http-server-api/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/Server.java
+++ b/http-server-api/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/Server.java
@@ -77,4 +77,12 @@ public interface Server {
 	 * @return The socket uri.
 	 */
 	URI getSocketUri();
+
+	/**
+	 * Register a runnable that is executed some time after the server is started.
+	 * 
+	 * @param hook
+	 *            The runnable to be executed.
+	 */
+	void registerOnPostStartHook(Runnable hook);
 }

--- a/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerImpl.java
+++ b/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerImpl.java
@@ -91,9 +91,6 @@ public class ServerImpl implements RunnableService, Server {
 	@Reference
 	private ServiceLocator di;
 
-	@Reference
-	private TaskScheduler scheduler;
-
 	private Set<Class<?>> restResources = new HashSet<>();
 	private HttpServer httpServer;
 

--- a/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerImpl.java
+++ b/http-server/src/main/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerImpl.java
@@ -23,28 +23,12 @@
 
 package de.unistuttgart.iaas.amyassist.amy.httpserver;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-
-import javax.ws.rs.Path;
-import javax.ws.rs.core.UriBuilder;
-
-import org.glassfish.grizzly.http.server.HttpServer;
-import org.glassfish.jersey.grizzly2.servlet.GrizzlyWebContainerFactory;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.slf4j.Logger;
-
 import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
 import de.unistuttgart.iaas.amyassist.amy.core.di.ServiceLocator;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.PostConstruct;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Reference;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Service;
 import de.unistuttgart.iaas.amyassist.amy.core.service.RunnableService;
-import de.unistuttgart.iaas.amyassist.amy.core.taskscheduler.api.TaskScheduler;
 import de.unistuttgart.iaas.amyassist.amy.httpserver.adapter.LocalDateTimeMessageBodyWriter;
 import de.unistuttgart.iaas.amyassist.amy.httpserver.adapter.LocalDateTimeProvider;
 import de.unistuttgart.iaas.amyassist.amy.httpserver.adapter.ZonedDateTimeMessageBodyWriter;
@@ -54,6 +38,19 @@ import de.unistuttgart.iaas.amyassist.amy.httpserver.di.DependencyInjectionBinde
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.servlet.GrizzlyWebContainerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 
 /**
  * A class to create a http server

--- a/http-server/src/test/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerTest.java
+++ b/http-server/src/test/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerTest.java
@@ -23,22 +23,23 @@
 
 package de.unistuttgart.iaas.amyassist.amy.httpserver;
 
-import static java.time.Duration.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Properties;
-
+import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
+import de.unistuttgart.iaas.amyassist.amy.core.di.DependencyInjection;
+import de.unistuttgart.iaas.amyassist.amy.core.di.provider.SingletonServiceProvider;
+import de.unistuttgart.iaas.amyassist.amy.core.taskscheduler.api.TaskScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
-import de.unistuttgart.iaas.amyassist.amy.core.di.DependencyInjection;
-import de.unistuttgart.iaas.amyassist.amy.core.di.provider.SingletonServiceProvider;
+import java.util.Properties;
+
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 /**
  * 
@@ -56,12 +57,15 @@ class ServerTest {
 		serverConfig.setProperty(ServerImpl.PROPERTY_LOCALHOST, "true");
 		serverConfig.setProperty(ServerImpl.PROPERTY_SERVER_URL, "");
 
+
+		TaskScheduler taskScheduler = Mockito.mock(TaskScheduler.class);
 		ConfigurationManager configManager = Mockito.mock(ConfigurationManager.class);
 		Mockito.when(configManager.getConfigurationWithDefaults(ServerImpl.CONFIG_NAME)).thenReturn(serverConfig);
 
 		this.dependencyInjection = new DependencyInjection();
 		this.dependencyInjection.register(new SingletonServiceProvider<>(ConfigurationManager.class, configManager));
 		this.dependencyInjection.register(new SingletonServiceProvider<>(Logger.class, LoggerFactory.getLogger(ServerImpl.class)));
+		this.dependencyInjection.register(new SingletonServiceProvider<>(TaskScheduler.class, taskScheduler));
 	}
 
 	@Test

--- a/http-server/src/test/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerTest.java
+++ b/http-server/src/test/java/de/unistuttgart/iaas/amyassist/amy/httpserver/ServerTest.java
@@ -23,23 +23,22 @@
 
 package de.unistuttgart.iaas.amyassist.amy.httpserver;
 
-import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
-import de.unistuttgart.iaas.amyassist.amy.core.di.DependencyInjection;
-import de.unistuttgart.iaas.amyassist.amy.core.di.provider.SingletonServiceProvider;
-import de.unistuttgart.iaas.amyassist.amy.core.taskscheduler.api.TaskScheduler;
+import static java.time.Duration.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Properties;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
-
-import static java.time.Duration.ofSeconds;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
+import de.unistuttgart.iaas.amyassist.amy.core.di.DependencyInjection;
+import de.unistuttgart.iaas.amyassist.amy.core.di.provider.SingletonServiceProvider;
 
 /**
  * 
@@ -57,15 +56,12 @@ class ServerTest {
 		serverConfig.setProperty(ServerImpl.PROPERTY_LOCALHOST, "true");
 		serverConfig.setProperty(ServerImpl.PROPERTY_SERVER_URL, "");
 
-
-		TaskScheduler taskScheduler = Mockito.mock(TaskScheduler.class);
 		ConfigurationManager configManager = Mockito.mock(ConfigurationManager.class);
 		Mockito.when(configManager.getConfigurationWithDefaults(ServerImpl.CONFIG_NAME)).thenReturn(serverConfig);
 
 		this.dependencyInjection = new DependencyInjection();
 		this.dependencyInjection.register(new SingletonServiceProvider<>(ConfigurationManager.class, configManager));
 		this.dependencyInjection.register(new SingletonServiceProvider<>(Logger.class, LoggerFactory.getLogger(ServerImpl.class)));
-		this.dependencyInjection.register(new SingletonServiceProvider<>(TaskScheduler.class, taskScheduler));
 	}
 
 	@Test

--- a/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
+++ b/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
@@ -271,7 +271,7 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 				stop();
 				start();
 			}
-		}, 5);
+		}, 10);
 	}
 
 	private void executeAfterSeconds(Runnable r, int seconds) {

--- a/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
+++ b/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
@@ -38,7 +38,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.function.Consumer;
 
-import de.unistuttgart.iaas.amyassist.amy.httpserver.Server;
+import javax.ws.rs.core.UriBuilder;
+
 import org.slf4j.Logger;
 
 import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
@@ -47,8 +48,7 @@ import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Reference;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Service;
 import de.unistuttgart.iaas.amyassist.amy.core.service.RunnableService;
 import de.unistuttgart.iaas.amyassist.amy.core.speech.SpeechRecognizer;
-
-import javax.ws.rs.core.UriBuilder;
+import de.unistuttgart.iaas.amyassist.amy.httpserver.Server;
 
 /**
  * Class to initiate the remote SR
@@ -61,6 +61,7 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 	private static final String CONFIG_NAME = "remotesr.config";
 	private static final String CHROME_DIRECTORY_CONFIG_KEY = "chromeCmd";
 	private static final String ENABLED_CONFIG_KEY = "enabled";
+	private static final String RESTART_TIME_CONFIG_KEY = "chromeRestartSeconds";
 
 	@Reference
 	private Logger logger;
@@ -82,11 +83,13 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 	private volatile boolean stop = false;
 
 	private boolean enabled;
+	private int chromeRestartTime;
 
 	@PostConstruct
 	private void init() {
-		this.enabled = Boolean.parseBoolean(
-				this.configurationManager.getConfigurationWithDefaults(CONFIG_NAME).getProperty(ENABLED_CONFIG_KEY));
+		Properties config = this.configurationManager.getConfigurationWithDefaults(CONFIG_NAME);
+		this.enabled = Boolean.parseBoolean(config.getProperty(ENABLED_CONFIG_KEY));
+		this.chromeRestartTime = Integer.parseInt(config.getProperty(RESTART_TIME_CONFIG_KEY));
 	}
 
 	private boolean isEnabled() {
@@ -157,13 +160,11 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 
 			String chromePath = config.getProperty(CHROME_DIRECTORY_CONFIG_KEY);
 
-			URI uri = httpServer.getSocketUri();
-			String hostString = UriBuilder
-					.fromPath(uri.getPath() + "/remotesr")
-					.scheme(uri.getScheme()).host("localhost").port(uri.getPort()).build().toString();
+			URI uri = this.httpServer.getSocketUri();
+			String hostString = UriBuilder.fromPath(uri.getPath() + "/remotesr").scheme(uri.getScheme())
+					.host("localhost").port(uri.getPort()).build().toString();
 
-			this.chromeProcess = new ProcessBuilder(chromePath, hostString,
-					"--user-data-dir=" + file).start();
+			this.chromeProcess = new ProcessBuilder(chromePath, hostString, "--user-data-dir=" + file).start();
 
 			watchProcess(new BufferedReader(
 					new InputStreamReader(this.chromeProcess.getInputStream(), StandardCharsets.UTF_8)));
@@ -228,10 +229,9 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 
 					if (relativeFile.equals("Default/Preferences")) {
 						// Replace host placeholder
-						URI uri = httpServer.getSocketUri();
-						String remoteSRHost = UriBuilder
-								.fromPath("")
-								.scheme(uri.getScheme()).host("localhost").port(uri.getPort()).build().toString();
+						URI uri = RemoteSR.this.httpServer.getSocketUri();
+						String remoteSRHost = UriBuilder.fromPath("").scheme(uri.getScheme()).host("localhost")
+								.port(uri.getPort()).build().toString();
 						String fileContent = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
 						fileContent = fileContent.replaceAll("\\{\\{REMOTESR_HOST}}", remoteSRHost);
 						Files.write(targetFilePath, fileContent.getBytes(StandardCharsets.UTF_8));
@@ -271,7 +271,7 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 				stop();
 				start();
 			}
-		}, 10);
+		}, this.chromeRestartTime);
 	}
 
 	private void executeAfterSeconds(Runnable r, int seconds) {

--- a/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
+++ b/remote-sr/src/main/java/de/unistuttgart/iaas/amyassist/amy/remotesr/RemoteSR.java
@@ -378,11 +378,13 @@ public class RemoteSR implements SpeechRecognizer, RunnableService {
 		if (!isEnabled())
 			return;
 
-		try {
-			launchChrome();
-		} catch (LaunchChromeException e) {
-			throw new IllegalStateException("Unable to launch chrome", e);
-		}
+		this.httpServer.registerOnPostStartHook(() -> {
+			try {
+				launchChrome();
+			} catch (LaunchChromeException e) {
+				throw new IllegalStateException("Unable to launch chrome", e);
+			}
+		});
 	}
 
 	/**

--- a/remote-sr/src/main/resources/META-INF/remotesr.config.properties
+++ b/remote-sr/src/main/resources/META-INF/remotesr.config.properties
@@ -1,2 +1,3 @@
 chromeCmd=/Program Files (x86)/Google/Chrome/Application/chrome.exe
 enabled=true
+chromeRestartSeconds=5


### PR DESCRIPTION
On some slower computers, Chrome can take longer than expected to start up and thereby DOS the RemoteSR-System.
Workaround: Increase maximum startup time before restart attempt from five to ten seconds.

This is a bug fix

Pull request status:
- [x] Code conventions
- [ ] Doku required and added
- [x] Ready for review
