### PR TITLE
Chat socket improvements

### DIFF
--- a/chat-socket/pom.xml
+++ b/chat-socket/pom.xml
@@ -37,6 +37,10 @@
 			<artifactId>minimal-json</artifactId>
 			<version>0.9.4</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>javax.ws.rs-api</artifactId>
+		</dependency>
 	</dependencies>
 	<description>Socket for chat communication</description>
 </project>

--- a/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatConfig.java
+++ b/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatConfig.java
@@ -1,0 +1,53 @@
+/*
+ * This source file is part of the Amy open source project.
+ * For more information see github.com/AmyAssist
+ * 
+ * Copyright (c) 2018 the Amy project authors.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information see notice.md
+ */
+
+package de.unistuttgart.iaas.amyassist.amy.socket;
+
+import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
+import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Reference;
+import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Service;
+
+import java.util.Properties;
+
+/**
+ * Config helper class for websocket server
+ *
+ * @author Benno Krauß
+ */
+@Service
+public class ChatConfig {
+    /** The name of the config used by this class */
+    private static final String CONFIG_NAME = "socket.config";
+    /** The name of the property, which specifies the port */
+    static final String PROPERTY_PORT = "webSocketPort";
+    /** The name of the property which specifies the websocket endpoint URL */
+    static final String WEBSOCKET_URL = "webSocketURL";
+
+    @Reference
+    private ConfigurationManager configurationManager;
+
+    String get(String key) {
+        Properties conf = this.configurationManager.getConfigurationWithDefaults(CONFIG_NAME);
+        return conf.getProperty(key);
+    }
+}

--- a/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatServer.java
+++ b/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatServer.java
@@ -23,16 +23,15 @@
 
 package de.unistuttgart.iaas.amyassist.amy.socket;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import org.slf4j.Logger;
-
-import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Reference;
 import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Service;
 import de.unistuttgart.iaas.amyassist.amy.core.natlang.DialogHandler;
 import de.unistuttgart.iaas.amyassist.amy.core.service.RunnableService;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+import static de.unistuttgart.iaas.amyassist.amy.socket.ChatConfig.PROPERTY_PORT;
 
 /**
  * the class running the server socket for the chat 
@@ -41,14 +40,9 @@ import de.unistuttgart.iaas.amyassist.amy.core.service.RunnableService;
  */
 @Service(ChatServer.class)
 public class ChatServer implements RunnableService {
-	
-	/** The name of the config used by this class */
-	public static final String CONFIG_NAME = "socket.config";
-	/** The name of the property, which specifies the port */
-	public static final String PROPERTY_PORT = "web.socket.port";
 
 	@Reference
-	private ConfigurationManager configurationManager;
+	ChatConfig config;
 	
 	@Reference
 	private Logger logger;
@@ -64,9 +58,8 @@ public class ChatServer implements RunnableService {
 	 */
 	@Override
 	public void start() {
-		Properties conf = this.configurationManager.getConfigurationWithDefaults(CONFIG_NAME);
-		int port = Integer.parseInt(conf.getProperty(PROPERTY_PORT));
-		
+
+		int port = Integer.parseInt(config.get(PROPERTY_PORT));
 		this.socket = new ChatWebSocket(port, this.handler);
 		this.socket.start();
 

--- a/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatWebSocket.java
+++ b/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/ChatWebSocket.java
@@ -40,7 +40,7 @@ import de.unistuttgart.iaas.amyassist.amy.core.natlang.DialogHandler;
 /**
  * A web socket for the chat communication 
  *  
- * @author Christian Bräuner
+ * @author Christian Bräuner, Benno Krauß
  */
 public class ChatWebSocket extends WebSocketServer {
 	

--- a/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/RestResource.java
+++ b/chat-socket/src/main/java/de/unistuttgart/iaas/amyassist/amy/socket/RestResource.java
@@ -1,0 +1,52 @@
+/*
+ * This source file is part of the Amy open source project.
+ * For more information see github.com/AmyAssist
+ * 
+ * Copyright (c) 2018 the Amy project authors.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information see notice.md
+ */
+
+package de.unistuttgart.iaas.amyassist.amy.socket;
+
+import de.unistuttgart.iaas.amyassist.amy.core.di.annotation.Reference;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static de.unistuttgart.iaas.amyassist.amy.socket.ChatConfig.WEBSOCKET_URL;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+/**
+ * Rest class to provide the web client the websocket endpoint URL
+ *
+ * @author Benno Krauß
+ */
+@Path("chat")
+public class RestResource {
+
+    @Reference
+    ChatConfig config;
+
+    @Path("url")
+    @Produces(TEXT_PLAIN)
+    @GET
+    public String getChatURL() {
+        return config.get(WEBSOCKET_URL);
+    }
+}

--- a/chat-socket/src/main/resources/META-INF/de.unistuttgart.iaas.amyassist.amy.core.di.Services
+++ b/chat-socket/src/main/resources/META-INF/de.unistuttgart.iaas.amyassist.amy.core.di.Services
@@ -1,1 +1,2 @@
 de.unistuttgart.iaas.amyassist.amy.socket.ChatServer
+de.unistuttgart.iaas.amyassist.amy.socket.ChatConfig

--- a/chat-socket/src/main/resources/META-INF/javax.ws.rs.Path
+++ b/chat-socket/src/main/resources/META-INF/javax.ws.rs.Path
@@ -1,0 +1,1 @@
+de.unistuttgart.iaas.amyassist.amy.socket.RestResource

--- a/chat-socket/src/main/resources/META-INF/socket.config.properties
+++ b/chat-socket/src/main/resources/META-INF/socket.config.properties
@@ -1,1 +1,1 @@
-web.socket.port=6661
+webSocketPort=6661

--- a/chat-socket/src/main/resources/META-INF/socket.config.properties
+++ b/chat-socket/src/main/resources/META-INF/socket.config.properties
@@ -1,1 +1,2 @@
 webSocketPort=6661
+webSocketURL=ws://localhost:6661/


### PR DESCRIPTION
Add http endpoint and config key for the websocket endpoint. This allows more flexibility when running Amy behind a reverse proxy and removes a bad regex hack