### PR TITLE
Navigation: Match location names and tags case-insensitively

### DIFF
--- a/plugins/navigation/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/navigation/RegistryConnection.java
+++ b/plugins/navigation/src/main/java/de/unistuttgart/iaas/amyassist/amy/plugin/navigation/RegistryConnection.java
@@ -59,9 +59,9 @@ public class RegistryConnection {
 		if (!locations.isEmpty()) {
 			address = locations.get(0);
 		} else {
-			// Try to find by name
+			// Try to find by name or tag ignoring case
 			for (Location location : this.locationRegistry.getAll()) {
-				if (location.getName().equals(name)) {
+				if (name.equalsIgnoreCase(location.getName()) || name.equalsIgnoreCase(location.getTag())) {
 					address = location;
 					break;
 				}


### PR DESCRIPTION
Now "Work" also works, where before amy wouldn't find it