### PR TITLE
fixed too many skips and low levensthein distance with short words

### DIFF
--- a/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
+++ b/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
@@ -133,7 +132,6 @@ public class NLProcessingManagerImpl implements NLProcessingManager {
 	public void processIntent(Dialog dialog, String naturalLanguageText) {
 		NLLexer nlLexer = new NLLexer(this.language);
 		List<EndToken> tokens = nlLexer.tokenize(naturalLanguageText);
-		System.out.println(StringUtils.join(naturalLanguageText));
 
 		if (!promptGrammarFound(dialog, tokens)) {
 			// try to skip prefixes and suffixes until a grammar matches

--- a/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
+++ b/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
@@ -137,11 +137,11 @@ public class NLProcessingManagerImpl implements NLProcessingManager {
 			// try to skip prefixes and suffixes until a grammar matches
 			for (int i = 0; i <= tokens.size(); i++) {
 				for (int j = tokens.size(); j > i; j--) {
-					if(tokens.subList(i, j).size() > 2) {
-						if (promptGrammarFound(dialog, tokens.subList(i, j))) {
-							return;
-						}
+					if (tokens.subList(i, j).size() > 2 &&
+							promptGrammarFound(dialog, tokens.subList(i, j))) {
+						return;
 					}
+					
 				}
 			}
 			this.logger.debug("no matching grammar found");
@@ -227,11 +227,11 @@ public class NLProcessingManagerImpl implements NLProcessingManager {
 		// try to skip prefixes and suffixes until a grammar matches
 		for (int i = 0; i <= tokens.size(); i++) {
 			for (int j = tokens.size(); j > i; j--) {
-				if(tokens.subList(i, j).size() > 2) {
-					if (intentFound(dialog, tokens.subList(i, j))) {
-						return dialog;
-					}
+				if (tokens.subList(i, j).size() > 2 &&
+						intentFound(dialog, tokens.subList(i, j))) {
+					return dialog;
 				}
+				
 			}
 		}
 

--- a/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
+++ b/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/NLProcessingManagerImpl.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import de.unistuttgart.iaas.amyassist.amy.core.configuration.ConfigurationManager;
@@ -132,12 +133,16 @@ public class NLProcessingManagerImpl implements NLProcessingManager {
 	public void processIntent(Dialog dialog, String naturalLanguageText) {
 		NLLexer nlLexer = new NLLexer(this.language);
 		List<EndToken> tokens = nlLexer.tokenize(naturalLanguageText);
+		System.out.println(StringUtils.join(naturalLanguageText));
+
 		if (!promptGrammarFound(dialog, tokens)) {
 			// try to skip prefixes and suffixes until a grammar matches
 			for (int i = 0; i <= tokens.size(); i++) {
 				for (int j = tokens.size(); j > i; j--) {
-					if (promptGrammarFound(dialog, tokens.subList(i, j))) {
-						return;
+					if(tokens.subList(i, j).size() > 2) {
+						if (promptGrammarFound(dialog, tokens.subList(i, j))) {
+							return;
+						}
 					}
 				}
 			}
@@ -224,8 +229,10 @@ public class NLProcessingManagerImpl implements NLProcessingManager {
 		// try to skip prefixes and suffixes until a grammar matches
 		for (int i = 0; i <= tokens.size(); i++) {
 			for (int j = tokens.size(); j > i; j--) {
-				if (intentFound(dialog, tokens.subList(i, j))) {
-					return dialog;
+				if(tokens.subList(i, j).size() > 2) {
+					if (intentFound(dialog, tokens.subList(i, j))) {
+						return dialog;
+					}
 				}
 			}
 		}

--- a/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/nl/NLParser.java
+++ b/natlang/src/main/java/de/unistuttgart/iaas/amyassist/amy/natlang/nl/NLParser.java
@@ -403,7 +403,7 @@ public class NLParser implements INLParser {
 			this.matchedStrings.add(toMatch.getContent());
 			return true;
 		}
-		if(!CompareWords.isDistanceBigger(nodeContent, tokenContent, 1)) {
+		if(nodeContent.length() > 3 && !CompareWords.isDistanceBigger(nodeContent, tokenContent, 1)) {
 			this.matchedStrings.add(toMatch.getContent());
 			return true;
 		}

--- a/plugins/timer/src/main/resources/TimerSpeech.aim.xml
+++ b/plugins/timer/src/main/resources/TimerSpeech.aim.xml
@@ -2,7 +2,7 @@
 <AmyInteractionModel>
 	<Intent
 		ref="de.unistuttgart.iaas.amyassist.amy.plugin.timer.TimerSpeech.setTimer">
-		<gram>(set|create) timer (for|on|at) [{hour} hour] [{minute} minute] [{second}second]
+		<gram>(set|create) [a] timer (for|on|at) [{hour} hour] [{minute} minute] [{second}second]
 		</gram>
 		<EntityTemplates>
 			<EntityTemplate id="hour" required="false">


### PR DESCRIPTION
this is a bugfix.
The pre and suffix skipping is now limited.
If pre and suffixes are beeing skipped the matching sentence length has to have at least 2 words.

Pull request status:
- [ ] Tests added/updated
- [ ] 80 % Coverage
- [ ] Code conventions
- [ ] Doku required and added
- [ ] Ready for review
