### PR TITLE
use openjdk 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
-#  - openjdk8
+  - openjdk8
 env:
   global:
     # GPG_KEY_NAME


### PR DESCRIPTION
travis updated java builds to not include the old java versions.
This PR change the oracle jdk to openjdk

Pull request status:
- [x] Ready for review
